### PR TITLE
Reorderable rows implementation

### DIFF
--- a/lib/material_table_view.dart
+++ b/lib/material_table_view.dart
@@ -1,5 +1,6 @@
 export './src/table_column.dart' show TableColumn;
 export './src/table_placeholder_shade.dart' show TablePlaceholderShade;
+export './src/table_row_reorder.dart' show TableRowReorder;
 export './src/table_view.dart' show TableView;
 export './src/table_view_controller.dart' show TableViewController;
 export './src/table_view_style.dart'

--- a/lib/src/optional_wrap.dart
+++ b/lib/src/optional_wrap.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/widgets.dart';
+
+class OptionalWrap extends StatelessWidget {
+  final Widget Function(BuildContext context, Widget child)? builder;
+  final Widget child;
+
+  const OptionalWrap({
+    super.key,
+    this.builder,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) => builder?.call(context, child) ?? child;
+}

--- a/lib/src/sliver_table_reorderable_list.dart
+++ b/lib/src/sliver_table_reorderable_list.dart
@@ -15,7 +15,7 @@ class SliverTableReorderableList extends SliverReorderableList {
     super.itemExtentBuilder,
     super.prototypeItem,
     super.proxyDecorator,
-    double? autoScrollerVelocityScalar,
+    super.autoScrollerVelocityScalar,
   });
 
   /// Makes the widget use the second next [Scrollable] parent rather than

--- a/lib/src/sliver_table_reorderable_list.dart
+++ b/lib/src/sliver_table_reorderable_list.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/widgets.dart';
+
+/// [SliverReorderableList] with workarounds for use in a table.
+class SliverTableReorderableList extends SliverReorderableList {
+  const SliverTableReorderableList({
+    super.key,
+    required super.itemBuilder,
+    super.findChildIndexCallback,
+    required super.itemCount,
+    required super.onReorder,
+    required this.useHigherScrollable,
+    super.onReorderStart,
+    super.onReorderEnd,
+    super.itemExtent,
+    super.itemExtentBuilder,
+    super.prototypeItem,
+    super.proxyDecorator,
+    double? autoScrollerVelocityScalar,
+  });
+
+  /// Makes the widget use the second next [Scrollable] parent rather than
+  /// the first one.
+  final bool useHigherScrollable;
+
+  @override
+  SliverReorderableListState createState() => _SliverTableViewBodyState();
+}
+
+class _SliverTableViewBodyState extends SliverReorderableListState {
+  BuildContext? _buildContextOverride;
+
+  @override
+  BuildContext get context => _buildContextOverride ?? super.context;
+
+  @override
+  void didChangeDependencies() {
+    if ((widget as SliverTableReorderableList).useHigherScrollable) {
+      // we make the parent state think it is higher on the hierarchy than
+      // it actually is for a brief moment so it will grab
+      // the correct scrollable
+      _buildContextOverride = Scrollable.of(context).context;
+    }
+
+    super.didChangeDependencies();
+
+    _buildContextOverride = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final originalSliverList =
+        super.build(context) as SliverMultiBoxAdaptorWidget;
+
+    // so we basically gutting this thing open just to build it back up
+    // with addRepaintBoundaries set to false
+
+    final originalDelegate =
+        originalSliverList.delegate as SliverChildBuilderDelegate;
+
+    final SliverChildBuilderDelegate childrenDelegate =
+        SliverChildBuilderDelegate(
+      originalDelegate.builder,
+      childCount: originalDelegate.childCount,
+      findChildIndexCallback: widget.findChildIndexCallback,
+      addRepaintBoundaries: false,
+    );
+
+    if (widget.itemExtent != null) {
+      return SliverFixedExtentList(
+        delegate: childrenDelegate,
+        itemExtent: widget.itemExtent!,
+      );
+    } else if (widget.itemExtentBuilder != null) {
+      return SliverVariedExtentList(
+        delegate: childrenDelegate,
+        itemExtentBuilder: widget.itemExtentBuilder!,
+      );
+    } else if (widget.prototypeItem != null) {
+      return SliverPrototypeExtentList(
+        delegate: childrenDelegate,
+        prototypeItem: widget.prototypeItem!,
+      );
+    }
+
+    return SliverList(delegate: childrenDelegate);
+  }
+}

--- a/lib/src/sliver_table_view.dart
+++ b/lib/src/sliver_table_view.dart
@@ -32,6 +32,7 @@ class SliverTableView extends TableView {
     required super.columns,
     this.horizontalScrollController,
     required super.rowBuilder,
+    super.rowReorder,
     super.placeholderBuilder,
     super.placeholderRowBuilder,
     super.placeholderShade,
@@ -43,7 +44,6 @@ class SliverTableView extends TableView {
     super.minScrollableWidth,
     super.minScrollableWidthRatio,
     super.textDirection,
-    super.onRowReorder,
   }) : super.builder();
 
   /// A scroll controller used for the horizontal scrolling of the table.
@@ -186,7 +186,7 @@ class _SliverTableViewState extends State<SliverTableView>
                                     verticalScrollOffsetPixels),
                                 placeholderShade: widget.placeholderShade,
                                 child: OptionalWrap(
-                                  builder: widget.onRowReorder == null
+                                  builder: widget.rowReorder == null
                                       ? null
                                       : (context, child) =>
                                           TableSectionOverlay(child: child),
@@ -200,12 +200,12 @@ class _SliverTableViewState extends State<SliverTableView>
                                         rowHeight: widget.rowHeight,
                                         rowCount: widget.rowCount,
                                         rowBuilder: widget.rowBuilder,
+                                        rowReorder: widget.rowReorder,
                                         placeholderBuilder:
                                             widget.placeholderBuilder,
                                         placeholderRowBuilder:
                                             widget.placeholderRowBuilder,
                                         useHigherScrollable: true,
-                                        onReorder: widget.onRowReorder,
                                       ),
                                     ),
                                   ),

--- a/lib/src/sliver_table_view.dart
+++ b/lib/src/sliver_table_view.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:material_table_view/src/optional_wrap.dart';
 import 'package:material_table_view/src/scroll_dimensions_applicator.dart';
 import 'package:material_table_view/src/sliver_table_view_body.dart';
 import 'package:material_table_view/src/table_column.dart';
@@ -12,6 +13,7 @@ import 'package:material_table_view/src/table_layout.dart';
 import 'package:material_table_view/src/table_row.dart';
 import 'package:material_table_view/src/table_scrollbar.dart';
 import 'package:material_table_view/src/table_section.dart';
+import 'package:material_table_view/src/table_section_overlay.dart';
 import 'package:material_table_view/src/table_view.dart';
 import 'package:material_table_view/src/table_view_style_resolved.dart';
 
@@ -31,6 +33,7 @@ class SliverTableView extends TableView {
     this.horizontalScrollController,
     required super.rowBuilder,
     super.placeholderBuilder,
+    super.placeholderRowBuilder,
     super.placeholderShade,
     super.bodyContainerBuilder,
     super.headerBuilder,
@@ -40,6 +43,7 @@ class SliverTableView extends TableView {
     super.minScrollableWidth,
     super.minScrollableWidthRatio,
     super.textDirection,
+    super.onRowReorder,
   }) : super.builder();
 
   /// A scroll controller used for the horizontal scrolling of the table.
@@ -181,18 +185,28 @@ class _SliverTableViewState extends State<SliverTableView>
                                 verticalOffset: ViewportOffset.fixed(
                                     verticalScrollOffsetPixels),
                                 placeholderShade: widget.placeholderShade,
-                                child: sliverBuilder(
-                                  sliver: SliverPadding(
-                                    padding: EdgeInsets.only(
-                                      top: scrollPadding.top,
-                                      bottom: scrollPadding.bottom,
-                                    ),
-                                    sliver: SliverTableViewBody(
-                                      rowHeight: widget.rowHeight,
-                                      rowCount: widget.rowCount,
-                                      rowBuilder: widget.rowBuilder,
-                                      placeholderBuilder:
-                                          widget.placeholderBuilder,
+                                child: OptionalWrap(
+                                  builder: widget.onRowReorder == null
+                                      ? null
+                                      : (context, child) =>
+                                          TableSectionOverlay(child: child),
+                                  child: sliverBuilder(
+                                    sliver: SliverPadding(
+                                      padding: EdgeInsets.only(
+                                        top: scrollPadding.top,
+                                        bottom: scrollPadding.bottom,
+                                      ),
+                                      sliver: SliverTableViewBody(
+                                        rowHeight: widget.rowHeight,
+                                        rowCount: widget.rowCount,
+                                        rowBuilder: widget.rowBuilder,
+                                        placeholderBuilder:
+                                            widget.placeholderBuilder,
+                                        placeholderRowBuilder:
+                                            widget.placeholderRowBuilder,
+                                        useHigherScrollable: true,
+                                        onReorder: widget.onRowReorder,
+                                      ),
                                     ),
                                   ),
                                 ),

--- a/lib/src/sliver_table_view_body.dart
+++ b/lib/src/sliver_table_view_body.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:material_table_view/src/sliver_table_reorderable_list.dart';
 import 'package:material_table_view/src/table_row.dart';
 import 'package:material_table_view/src/table_typedefs.dart';
 
@@ -8,6 +9,9 @@ class SliverTableViewBody extends StatelessWidget {
   final double rowHeight;
   final TableRowBuilder rowBuilder;
   final TablePlaceholderBuilder placeholderBuilder;
+  final TablePlaceholderRowBuilder? placeholderRowBuilder;
+  final void Function(int a, int b)? onReorder;
+  final bool useHigherScrollable;
 
   const SliverTableViewBody({
     super.key,
@@ -15,14 +19,30 @@ class SliverTableViewBody extends StatelessWidget {
     required this.rowHeight,
     required this.rowBuilder,
     required this.placeholderBuilder,
+    required this.placeholderRowBuilder,
+    required this.useHigherScrollable,
+    required this.onReorder,
   });
 
   @override
   Widget build(BuildContext context) {
-    late final placeholder = placeholderBuilder.call(
-      context,
-      placeholderContentBuilder,
-    );
+    Widget? placeholder;
+
+    if (onReorder != null) {
+      return SliverTableReorderableList(
+        itemBuilder: (context, index) =>
+            rowBuilder(context, index, contentBuilder) ??
+            placeholder ??
+            placeholderRowBuilder?.call(
+                context, index, placeholderContentBuilder) ??
+            (placeholder ??=
+                placeholderBuilder.call(context, placeholderContentBuilder)),
+        itemCount: rowCount,
+        onReorder: onReorder!,
+        itemExtent: rowHeight,
+        useHigherScrollable: useHigherScrollable,
+      );
+    }
 
     return SliverFixedExtentList(
       itemExtent: rowHeight,
@@ -30,7 +50,12 @@ class SliverTableViewBody extends StatelessWidget {
         childCount: rowCount,
         addRepaintBoundaries: false,
         (context, index) =>
-            rowBuilder(context, index, contentBuilder) ?? placeholder,
+            rowBuilder(context, index, contentBuilder) ??
+            placeholder ??
+            placeholderRowBuilder?.call(
+                context, index, placeholderContentBuilder) ??
+            (placeholder ??=
+                placeholderBuilder.call(context, placeholderContentBuilder)),
       ),
     );
   }

--- a/lib/src/sliver_table_view_body.dart
+++ b/lib/src/sliver_table_view_body.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:material_table_view/src/sliver_table_reorderable_list.dart';
 import 'package:material_table_view/src/table_row.dart';
+import 'package:material_table_view/src/table_row_reorder.dart';
 import 'package:material_table_view/src/table_typedefs.dart';
 
 /// This is a sliver widget that builds rows of a table.
@@ -10,7 +11,7 @@ class SliverTableViewBody extends StatelessWidget {
   final TableRowBuilder rowBuilder;
   final TablePlaceholderBuilder placeholderBuilder;
   final TablePlaceholderRowBuilder? placeholderRowBuilder;
-  final void Function(int a, int b)? onReorder;
+  final TableRowReorder? rowReorder;
   final bool useHigherScrollable;
 
   const SliverTableViewBody({
@@ -21,14 +22,15 @@ class SliverTableViewBody extends StatelessWidget {
     required this.placeholderBuilder,
     required this.placeholderRowBuilder,
     required this.useHigherScrollable,
-    required this.onReorder,
+    required this.rowReorder,
   });
 
   @override
   Widget build(BuildContext context) {
     Widget? placeholder;
 
-    if (onReorder != null) {
+    final rowReorder = this.rowReorder;
+    if (rowReorder != null) {
       return SliverTableReorderableList(
         itemBuilder: (context, index) =>
             rowBuilder(context, index, contentBuilder) ??
@@ -38,9 +40,14 @@ class SliverTableViewBody extends StatelessWidget {
             (placeholder ??=
                 placeholderBuilder.call(context, placeholderContentBuilder)),
         itemCount: rowCount,
-        onReorder: onReorder!,
         itemExtent: rowHeight,
         useHigherScrollable: useHigherScrollable,
+        onReorder: rowReorder.onReorder,
+        autoScrollerVelocityScalar: rowReorder.autoScrollerVelocityScalar,
+        findChildIndexCallback: rowReorder.findChildIndexCallback,
+        onReorderStart: rowReorder.onReorderStart,
+        onReorderEnd: rowReorder.onReorderEnd,
+        proxyDecorator: rowReorder.proxyDecorator,
       );
     }
 

--- a/lib/src/table_row_reorder.dart
+++ b/lib/src/table_row_reorder.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+
+/// Holds properties to enable row reordering in a table.
+class TableRowReorder {
+  /// See [SliverReorderableList.findChildIndexCallback].
+  final ChildIndexGetter? findChildIndexCallback;
+
+  /// See [SliverReorderableList.onReorder].
+  final ReorderCallback onReorder;
+
+  /// See [SliverReorderableList.onReorderStart].
+  final void Function(int)? onReorderStart;
+
+  /// See [SliverReorderableList.onReorderEnd].
+  final void Function(int)? onReorderEnd;
+
+  /// See [SliverReorderableList.proxyDecorator].
+  final ReorderItemProxyDecorator? proxyDecorator;
+
+  /// See [SliverReorderableList.autoScrollerVelocityScalar].
+  final double? autoScrollerVelocityScalar;
+
+  TableRowReorder({
+    required this.onReorder,
+    this.onReorderStart,
+    this.onReorderEnd,
+    this.findChildIndexCallback,
+    this.proxyDecorator,
+    this.autoScrollerVelocityScalar,
+  });
+}

--- a/lib/src/table_section_overlay.dart
+++ b/lib/src/table_section_overlay.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 class TableSectionOverlay extends StatefulWidget {
@@ -19,19 +20,29 @@ class _TableSectionOverlayState extends State<TableSectionOverlay> {
   void initState() {
     super.initState();
 
-    // TODO get semantics working somehow
-
     _overlayEntry = OverlayEntry(
-      builder: (context) => Semantics(
-        excludeSemantics: true,
-        child: widget.child,
-      ),
+      builder: (context) => widget.child,
     );
   }
 
   @override
-  Widget build(BuildContext context) => Overlay(
-        clipBehavior: Clip.none,
-        initialEntries: [_overlayEntry],
+  Widget build(BuildContext context) {
+    Widget w = Overlay(
+      clipBehavior: Clip.none,
+      initialEntries: [_overlayEntry],
+    );
+
+    if (kDebugMode) {
+      // This avoids assertion in _ScrollSemantics.assembleSemanticsNode
+      // that checks that semantics children are tagged as
+      // RenderViewport.useTwoPaneSemantics.
+      // Semantics should work just fine at release builds.
+      w = Semantics(
+        excludeSemantics: true,
+        child: w,
       );
+    }
+
+    return w;
+  }
 }

--- a/lib/src/table_section_overlay.dart
+++ b/lib/src/table_section_overlay.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/widgets.dart';
+
+class TableSectionOverlay extends StatefulWidget {
+  final Widget child;
+
+  const TableSectionOverlay({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  State<TableSectionOverlay> createState() => _TableSectionOverlayState();
+}
+
+class _TableSectionOverlayState extends State<TableSectionOverlay> {
+  late OverlayEntry _overlayEntry;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // TODO get semantics working somehow
+
+    _overlayEntry = OverlayEntry(
+      builder: (context) => Semantics(
+        excludeSemantics: true,
+        child: widget.child,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => Overlay(
+        clipBehavior: Clip.none,
+        initialEntries: [_overlayEntry],
+      );
+}

--- a/lib/src/table_typedefs.dart
+++ b/lib/src/table_typedefs.dart
@@ -25,7 +25,7 @@ typedef TablePlaceholderBuilder = Widget Function(
 
 /// Function used to build the final widget representing the placeholder row
 /// of a table.
-typedef TablePlaceholderRowBuilder = Widget Function(
+typedef TablePlaceholderRowBuilder = Widget? Function(
   BuildContext context,
   int row,
   TableRowContentBuilder contentBuilder,

--- a/lib/src/table_typedefs.dart
+++ b/lib/src/table_typedefs.dart
@@ -23,7 +23,7 @@ typedef TablePlaceholderBuilder = Widget Function(
   TableRowContentBuilder contentBuilder,
 );
 
-/// Function used to build the final widget representing the placeholder row
+/// Function used to build the final widget representing a placeholder row
 /// of a table.
 typedef TablePlaceholderRowBuilder = Widget? Function(
   BuildContext context,

--- a/lib/src/table_typedefs.dart
+++ b/lib/src/table_typedefs.dart
@@ -16,9 +16,18 @@ typedef TableRowBuilder = Widget? Function(
   TableRowContentBuilder contentBuilder,
 );
 
-/// Function used to build the final widget representing the placeholder of a table.
+/// Function used to build the final widget used for
+/// all the placeholder of a table.
 typedef TablePlaceholderBuilder = Widget Function(
   BuildContext context,
+  TableRowContentBuilder contentBuilder,
+);
+
+/// Function used to build the final widget representing the placeholder row
+/// of a table.
+typedef TablePlaceholderRowBuilder = Widget Function(
+  BuildContext context,
+  int row,
   TableRowContentBuilder contentBuilder,
 );
 

--- a/lib/src/table_view.dart
+++ b/lib/src/table_view.dart
@@ -79,6 +79,15 @@ class TableView extends StatefulWidget {
   /// [placeholderBuilder] property.
   final TableRowBuilder rowBuilder;
 
+  /// When a non-null value is specified, [SliverReorderableList] instantiated
+  /// using properties from this object will be used by the table.
+  /// This enables row reordering using the same way as one would
+  /// working with [ReorderableListView]. This also means that each row widget
+  /// built by a [rowBuilder] is required to have a unique key.
+  ///
+  /// Changing this property from null to non-null value (and vice versa)
+  /// for currently live widget will lead to state loss of all the rows and
+  /// cells.
   final TableRowReorder? rowReorder;
 
   /// A function that will be called on-demand for building the placeholder
@@ -88,6 +97,15 @@ class TableView extends StatefulWidget {
   /// [placeholderShade] can be used to apply a shader to the widgets painted.
   final TablePlaceholderBuilder placeholderBuilder;
 
+  /// A function that will be called on-demand for building a placeholder
+  /// row widget. As oppose to [placeholderBuilder], this function gets called
+  /// to build every placeholder row individually. Consider using
+  /// [placeholderBuilder] when all placeholder rows are the same as each other.
+  ///
+  /// When this function is `null` or it returns `null` the result of
+  /// [placeholderBuilder] function call will be used instead.
+  ///
+  /// [placeholderShade] can be used to apply a shader to the widgets painted.
   final TablePlaceholderRowBuilder? placeholderRowBuilder;
 
   /// A callback that allows application of a shader to the placeholder rows.

--- a/lib/src/table_view.dart
+++ b/lib/src/table_view.dart
@@ -10,6 +10,7 @@ import 'package:material_table_view/src/table_horizontal_divider.dart';
 import 'package:material_table_view/src/table_layout.dart';
 import 'package:material_table_view/src/table_placeholder_shade.dart';
 import 'package:material_table_view/src/table_row.dart';
+import 'package:material_table_view/src/table_row_reorder.dart';
 import 'package:material_table_view/src/table_scroll_configuration.dart';
 import 'package:material_table_view/src/table_scrollbar.dart';
 import 'package:material_table_view/src/table_section.dart';
@@ -44,7 +45,7 @@ class TableView extends StatefulWidget {
     this.minScrollableWidth,
     this.minScrollableWidthRatio,
     this.textDirection,
-    this.onRowReorder,
+    this.rowReorder,
   })  : assert(rowCount >= 0),
         assert(rowHeight > 0),
         assert(headerHeight == null || headerHeight > 0),
@@ -77,6 +78,8 @@ class TableView extends StatefulWidget {
   /// replaced with a placeholder. This enables additional behaviour described in a
   /// [placeholderBuilder] property.
   final TableRowBuilder rowBuilder;
+
+  final TableRowReorder? rowReorder;
 
   /// A function that will be called on-demand for building the placeholder
   /// row widget. It never gets called more than once per build cycle as the
@@ -135,8 +138,6 @@ class TableView extends StatefulWidget {
   /// If null, the value from the closest instance
   /// of the [Directionality] class that encloses the table will be used.
   final TextDirection? textDirection;
-
-  final void Function(int oldIndex, int newIndex)? onRowReorder;
 
   @override
   State<TableView> createState() => _TableViewState();
@@ -277,7 +278,7 @@ class _TableViewState extends State<TableView>
                               rowHeight: widget.rowHeight,
                               placeholderShade: widget.placeholderShade,
                               child: OptionalWrap(
-                                builder: widget.onRowReorder == null
+                                builder: widget.rowReorder == null
                                     ? null
                                     : (context, child) =>
                                         TableSectionOverlay(child: child),
@@ -299,7 +300,7 @@ class _TableViewState extends State<TableView>
                                         placeholderRowBuilder:
                                             widget.placeholderRowBuilder,
                                         useHigherScrollable: false,
-                                        onReorder: widget.onRowReorder,
+                                        rowReorder: widget.rowReorder,
                                       ),
                                     ),
                                   ],


### PR DESCRIPTION
This adds reorderable row support using `SliverReorderableList` included in the Flutter framework.

The only thing preventing this from landing is semantics, which had to be disabled to avoid triggering assertion in the framework (the place is marked with a `TODO`). The offending assertion is in the source of `_ScrollSemantics.assembleSemanticsNode(...)`. It asserts that a child semantics node must be tagged with `RenderViewport.useTwoPaneSemantics`. I assume the problem is that the children of the `Overlay` are not getting tagged as such.

Possible solutions are:
- to file an issue at Flutter to consider removing the unnamed assertion as it doesn't seem to be that necessary;
- to find a workaround that tags children with `RenderViewport.useTwoPaneSemantics` which will (from initial inspection) require almost complete reimplementation of `Overlay` just to get to the one right place;
- ~~to disable semantics and just roll with it~~ (not the best option IMO).