### PR TITLE
Remove default scrollbar style values

### DIFF
--- a/lib/src/table_view_style_resolved.dart
+++ b/lib/src/table_view_style_resolved.dart
@@ -396,14 +396,10 @@ class ResolvedTableViewScrollbarStyle extends TableViewScrollbarStyle {
       effectivelyEnabled: effectivelyEnabled,
       scrollPadding: effectivelyEnabled &&
           (style?.scrollPadding ?? base?.scrollPadding ?? true),
-      thumbVisibility: style?.thumbVisibility ??
-          base?.thumbVisibility ??
-          const MaterialStatePropertyAll(true),
+      thumbVisibility: style?.thumbVisibility ?? base?.thumbVisibility,
       thickness: style?.thickness ?? base?.thickness,
-      trackVisibility: style?.trackVisibility ??
-          base?.trackVisibility ??
-          const MaterialStatePropertyAll(true),
-      interactive: style?.interactive ?? base?.interactive ?? true,
+      trackVisibility: style?.trackVisibility ?? base?.trackVisibility,
+      interactive: style?.interactive ?? base?.interactive,
       radius: style?.radius ?? base?.radius,
       thumbColor: style?.thumbColor ?? base?.thumbColor,
       trackColor: style?.trackColor ?? base?.trackColor,


### PR DESCRIPTION
A few days ago I've decided to drop my old local version of `material_table_view` (it was based on v3.2.1) and use the releases available on pub. It looks great! Thanks!

I just noticed that default behavior of scrollbar for table view is different from what Flutter's own scrollbar behavior and found that you're using some default values in `ResolvedTableViewScrollbarStyle` that's causing this issue. I think it's better to keep values as `null` if nothing is provided by user.