### PR TITLE
Fix logic of computeMaxIntrinsicHeight for TableViewRow

### DIFF
--- a/lib/src/table_row.dart
+++ b/lib/src/table_row.dart
@@ -388,7 +388,7 @@ class _RenderTableViewRow extends RenderBox {
 
     for (final child in children.values) {
       height = max(
-        0,
+        height,
         child.getMaxIntrinsicHeight(
             (child.parentData as _TableViewCellParentData).width),
       );


### PR DESCRIPTION
Thanks for this great library. I wanted all my cells inside TableViewRow to have the same height. To achieve that, we need to wrap the result of contentBuilder with IntrinsicHeight. As a result of my action, all cells in rows had the same height. 

However, I found out that text in some cells was clipped, because calculation logic of maximum intrinsic height had small bug