### PR TITLE
Fix dynamic row height bug

### DIFF
--- a/lib/src/sliver_table_view.dart
+++ b/lib/src/sliver_table_view.dart
@@ -51,6 +51,7 @@ class SliverTableView extends TableView {
     super.footerBuilder,
     super.footerHeight,
     super.physicsHorizontal,
+    super.shouldRenderColumnsLazy,
   }) : super.builder(physics: null);
 
   /// A scroll controller used for the horizontal scrolling of the table.
@@ -149,6 +150,7 @@ class _SliverTableViewState extends State<SliverTableView>
                     columns: columns,
                     scrollPadding: scrollPadding,
                     child: TableContentLayout(
+                      shouldRenderColumnsLazy: widget.shouldRenderColumnsLazy,
                       verticalDividersStyle: style.dividers.vertical,
                       width: width,
                       fixedRowHeight: true,

--- a/lib/src/table_content_layout.dart
+++ b/lib/src/table_content_layout.dart
@@ -225,7 +225,7 @@ class TableContentLayoutState extends State<TableContentLayout>
                   ? column.width + widget.scrollPadding.right
                   : 0) <=
           widget.width) {
-        if (widget.shouldRenderColumnsLazy && centerOffset >= -column.width) {
+        if (!widget.shouldRenderColumnsLazy || centerOffset >= -column.width) {
           columnsCenter.add(i);
           columnOffsetsCenter.add(centerOffset);
         }

--- a/lib/src/table_content_layout.dart
+++ b/lib/src/table_content_layout.dart
@@ -219,44 +219,53 @@ class TableContentLayoutState extends State<TableContentLayout>
         columnsLeft.add(i);
         columnOffsetsLeft.add(leftOffset);
         leftOffset += column.width;
-      } else if (leftOffset +
-              centerOffset +
-              (column.frozenAt(freezePriority)
-                  ? column.width + widget.scrollPadding.right
-                  : 0) <=
-          widget.width) {
-        if (!widget.shouldRenderColumnsLazy || centerOffset >= -column.width) {
-          columnsCenter.add(i);
-          columnOffsetsCenter.add(centerOffset);
-        }
-        centerOffset += column.width;
       } else {
-        sticky = true;
-        i = max(0, i - 2);
-        for (int j = columns.length - 1; j > i && j >= 0; j--) {
-          final column = columns[j];
-          if (column.frozenAt(freezePriority)) {
-            if (column.sticky && sticky) {
-              _maxStickyHorizontalOffset += column.width;
-            } else {
-              sticky = false;
-            }
+        final columnFitsInVisibleArea = (leftOffset +
+                centerOffset +
+                (column.frozenAt(freezePriority)
+                    ? column.width + widget.scrollPadding.right
+                    : 0)) <=
+            widget.width;
 
-            columnsRight.add(j);
-            rightOffset -= column.width;
-            columnOffsetsRight.add(rightOffset);
+        // when lazy rendering is disabled, we still want to include
+        // columns that don’t fit *provided* they are not frozen – frozen
+        // columns on the right must be handled by the dedicated branch
+        final shouldDisplayColumn =
+            (!widget.shouldRenderColumnsLazy && !column.frozenAt(freezePriority));
 
-            final maxVisibleOffset = widget.width - leftOffset + rightOffset;
-            while (columnsCenter.isNotEmpty &&
-                columnOffsetsCenter.last > maxVisibleOffset) {
-              columnsCenter.removeLast();
-              columnOffsetsCenter.removeLast();
-              i--;
+        if (columnFitsInVisibleArea || shouldDisplayColumn) {
+          if (!widget.shouldRenderColumnsLazy || centerOffset >= -column.width) {
+            columnsCenter.add(i);
+            columnOffsetsCenter.add(centerOffset);
+          }
+          centerOffset += column.width;
+        } else {
+          sticky = true;
+          i = max(0, i - 2);
+          for (int j = columns.length - 1; j > i && j >= 0; j--) {
+            final column = columns[j];
+            if (column.frozenAt(freezePriority)) {
+              if (column.sticky && sticky) {
+                _maxStickyHorizontalOffset += column.width;
+              } else {
+                sticky = false;
+              }
+
+              columnsRight.add(j);
+              rightOffset -= column.width;
+              columnOffsetsRight.add(rightOffset);
+
+              final maxVisibleOffset = widget.width - leftOffset + rightOffset;
+              while (columnsCenter.isNotEmpty && columnOffsetsCenter.last > maxVisibleOffset) {
+                columnsCenter.removeLast();
+                columnOffsetsCenter.removeLast();
+                i--;
+              }
             }
           }
-        }
 
-        break;
+          break;
+        }
       }
     }
 

--- a/lib/src/table_content_layout.dart
+++ b/lib/src/table_content_layout.dart
@@ -24,6 +24,7 @@ class TableContentLayout extends StatefulWidget {
   final double minScrollableWidthRatio;
   final TextDirection textDirection;
   final EdgeInsets scrollPadding;
+  final bool shouldRenderColumnsLazy;
   final Widget child;
 
   const TableContentLayout({
@@ -39,6 +40,7 @@ class TableContentLayout extends StatefulWidget {
     required this.textDirection,
     required this.scrollPadding,
     required this.child,
+    required this.shouldRenderColumnsLazy,
   });
 
   static TableContentLayoutData of(BuildContext context) {
@@ -223,7 +225,7 @@ class TableContentLayoutState extends State<TableContentLayout>
                   ? column.width + widget.scrollPadding.right
                   : 0) <=
           widget.width) {
-        if (centerOffset >= -column.width) {
+        if (widget.shouldRenderColumnsLazy && centerOffset >= -column.width) {
           columnsCenter.add(i);
           columnOffsetsCenter.add(centerOffset);
         }

--- a/lib/src/table_view.dart
+++ b/lib/src/table_view.dart
@@ -56,6 +56,7 @@ class TableView extends StatefulWidget {
     this.physicsHorizontal,
     this.shrinkWrapVertical = false,
     this.shrinkWrapHorizontal = false,
+    this.shouldRenderColumnsLazy = true,
   })  : assert(rowCount >= 0),
         assert(rowHeight == null || rowHeight > 0),
         assert(headerHeight == null || headerHeight > 0),
@@ -308,6 +309,13 @@ class TableView extends StatefulWidget {
   /// Defaults to false.
   final bool shrinkWrapHorizontal;
 
+  /// Whether to render columns lazily.
+  ///
+  /// If true, columns will be rendered only when they are visible.
+  ///
+  /// Defaults to true.
+  final bool shouldRenderColumnsLazy;
+
   @override
   State<TableView> createState() => _TableViewState();
 }
@@ -416,6 +424,7 @@ class _TableViewState extends State<TableView>
             horizontalOffset: horizontalOffset,
             stickyHorizontalOffset: _stickyHorizontalOffset,
             minScrollableWidth: widget.minScrollableWidth,
+            shouldRenderColumnsLazy: widget.shouldRenderColumnsLazy,
             child: Builder(
               builder: (context) => TableScaffold(
                 shrinkWrapVertical: widget.shrinkWrapVertical,


### PR DESCRIPTION

https://github.com/user-attachments/assets/c33593a0-cf01-478d-81f9-d1afd22033c7

Currently, the table's layout changes when scrolling if the heights of rows are calculated (not specified). This is happening because RenderBoxes outside of the viewport are being detached. That's a feature, not a bug (~visualization). 
But it creates a new issue - the layout of the table will change dynamically. So I would like to have control over that. With flag shouldRenderColumnsLazy to "false" it will avoid detaching renderboxes. 