### PR TITLE
Expose `Key` for Horizontal & Vertical `Scrollable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.5.3
+- Fixed incompatibility with Flutter 3.32.x or lower.
+- Added `horizontalScrollKey` and `verticalScrollKey` to `TableViewController`.
+
 ## 5.5.2
 - Fixed incompatibility with Flutter 3.35.
 - Added constraint on Flutter version >=3.35.0.

--- a/lib/src/table_view.dart
+++ b/lib/src/table_view.dart
@@ -374,6 +374,7 @@ class _TableViewState extends State<TableView>
               offset: horizontalScrollbarOffset,
               transformHitTests: false,
               child: Scrollable(
+                key: _controller.horizontalScrollKey,
                 controller: _controller.horizontalScrollController,
                 clipBehavior: Clip.none,
                 axisDirection: textDirectionToAxisDirection(textDirection),
@@ -447,6 +448,7 @@ class _TableViewState extends State<TableView>
                         controller: _controller.verticalScrollController,
                         style: style.scrollbars.vertical,
                         child: Scrollable(
+                          key: _controller.verticalScrollKey,
                           controller: _controller.verticalScrollController,
                           clipBehavior: Clip.none,
                           axisDirection: AxisDirection.down,

--- a/lib/src/table_view_controller.dart
+++ b/lib/src/table_view_controller.dart
@@ -8,6 +8,14 @@ class TableViewController {
   /// Controller used to hold vertical scroll state of a table.
   final verticalScrollController = ScrollController();
 
+  /// [Key] supplied to the horizontal [Scrollable].
+  /// This may be used to persist (save & restore) the scroll position of the horizontal scroll using [PageStorageKey].
+  final Key? horizontalScrollKey = null;
+
+  /// [Key] supplied to the vertical [Scrollable].
+  /// This may be used to persist (save & restore) the scroll position of the vertical scroll using [PageStorageKey].
+  final Key? verticalScrollKey = null;
+
   /// Discards any resources used by the object. After this is called, the
   /// object is not in a usable state and should be discarded.
   ///

--- a/lib/src/table_view_style.dart
+++ b/lib/src/table_view_style.dart
@@ -147,6 +147,11 @@ class TableViewHorizontalDividersStyle {
 /// Defines a display style of a particular horizontal divider of a table.
 @immutable
 class TableViewHorizontalDividerStyle extends DividerThemeData {
+  @override
+  // For backward compatibility with Flutter 3.32.x or lower.
+  // ignore: override_on_non_overriding_member, overridden_fields
+  final BorderRadiusGeometry? radius;
+
   const TableViewHorizontalDividerStyle({
     this.enabled = true,
     super.color,
@@ -154,7 +159,7 @@ class TableViewHorizontalDividerStyle extends DividerThemeData {
     super.space,
     super.indent,
     super.endIndent,
-    super.radius,
+    this.radius,
   })  : assert(thickness == null || thickness >= 0),
         assert(space == null || space >= 0),
         assert(indent == null || indent >= 0),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ topics:
 
 environment:
   sdk: ">=2.17.1 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.32.0"
 
 screenshots:
   - description: 'Regular box TableView demo running on Windows laptop'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ topics:
 
 environment:
   sdk: ">=2.17.1 <4.0.0"
-  flutter: ">=3.32.0"
 
 screenshots:
   - description: 'Regular box TableView demo running on Windows laptop'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Comprehensive, feature-rich and intuitive UI/UX widget solution for
 repository: 'https://github.com/NikolayNIK/material_table_view'
 issue_tracker: 'https://github.com/NikolayNIK/material_table_view/issues'
 
-version: 5.5.2
+version: 5.5.3
 
 topics:
   - table


### PR DESCRIPTION
### Summary

- Expose optional `Key` for horizontal & vertical `Scrollable`.
  - This allows to persist the scroll position between unmount & mount of the widget using [`PageStorageKey`](https://api.flutter.dev/flutter/widgets/PageStorageKey-class.html).
- Support Flutter 3.32.x or lower.
  - By declaring `radius` within the subclass (https://github.com/flutter/flutter/pull/169739).